### PR TITLE
fix(U2FAuthenticator): changes equals check to string

### DIFF
--- a/Security/TwoFactor/Prodiver/U2F/U2FAuthenticator.php
+++ b/Security/TwoFactor/Prodiver/U2F/U2FAuthenticator.php
@@ -26,7 +26,7 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         $scheme = $requestStack->getCurrentRequest()->getScheme();
         $host = $requestStack->getCurrentRequest()->getHost();
         $port = $requestStack->getCurrentRequest()->getPort();
-        $this->u2f = new \u2flib_server\U2F($scheme.'://'.$host.((80 !== $port && 443 !== $port)?':'.$port:''));
+        $this->u2f = new \u2flib_server\U2F($scheme.'://'.$host.(('80' !== $port && '443' !== $port)?':'.$port:''));
     }
     /**
      * generateRequest


### PR DESCRIPTION
[getPort()](http://api.symfony.com/2.8/Symfony/Component/HttpFoundation/Request.html#method_getPort) returns a string instead of an integer.