### PR TITLE
fix(U2FAuthenticator): cast port to int

### DIFF
--- a/Security/TwoFactor/Prodiver/U2F/U2FAuthenticator.php
+++ b/Security/TwoFactor/Prodiver/U2F/U2FAuthenticator.php
@@ -26,7 +26,8 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         $scheme = $requestStack->getCurrentRequest()->getScheme();
         $host = $requestStack->getCurrentRequest()->getHost();
         $port = $requestStack->getCurrentRequest()->getPort();
-        $this->u2f = new \u2flib_server\U2F($scheme.'://'.$host.((80 !== $port && 443 !== $port)?':'.$port:''));
+        $intPort = (int) $port;
+        $this->u2f = new \u2flib_server\U2F($scheme.'://'.$host.((80 !== $intPort && 443 !== $intPort)?':'.$port:''));
     }
     /**
      * generateRequest


### PR DESCRIPTION
The port should be casted to int, because of this:
> can be a string if fetched from the server bag

https://github.com/symfony/symfony/blob/33d4bce1f9b931db0cbac0db3b7c6b272b16e7f9/src/Symfony/Component/HttpFoundation/Request.php#L997

Closes https://github.com/darookee/u2f-two-factor-bundle/issues/15