### PR TITLE
Use FQCN as service name

### DIFF
--- a/Controller/RegisterController.php
+++ b/Controller/RegisterController.php
@@ -5,6 +5,7 @@ namespace R\U2FTwoFactorBundle\Controller;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use R\U2FTwoFactorBundle\Event\RegisterEvent;
+use R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator;
 
 /**
  * Class RegisterController
@@ -19,7 +20,7 @@ class RegisterController extends Controller
      **/
     public function u2fAction(Request $request)
     {
-        $u2fAuthenticator = $this->get('r_u2f_two_factor.authenticator');
+        $u2fAuthenticator = $this->get(U2FAuthenticator::class);
         if ($request->isMethod('POST')) {
             $registerData = json_decode($request->get('_auth_code'));
             $registrationRequest = json_decode($this->get('session')->get('u2f_registrationRequest'));

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,12 +1,10 @@
 services:
-    r_u2f_two_factor.authenticator:
-        class: R\U2FTwoFactorBundle\Security\TwoFactor\Prodiver\U2F\U2FAuthenticator
+    R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator:
         arguments:
             - '@request_stack'
-    r_u2f_two_factor.provider:
-        class: R\U2FTwoFactorBundle\Security\TwoFactor\Prodiver\U2F\TwoFactorProvider
+    R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\TwoFactorProvider:
         arguments:
-            - '@r_u2f_two_factor.authenticator'
+            - '@R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator'
             - '@templating'
             - '%r_u2f_two_factor.formtemplate%'
             - '%r_u2f_two_factor.authcodeparameter%'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,5 +1,6 @@
 services:
     R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator:
+        public: true
         arguments:
             - '@request_stack'
     R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\TwoFactorProvider:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
         "scheb/two-factor-bundle": "^2.0",
         "yubico/u2flib-server": "^1.0.0"
     },


### PR DESCRIPTION
scheb/two-factor-bundle requires Symfony 3.4, so we can use a FQCN as a service name: https://symfony.com/blog/new-in-symfony-3-3-optional-class-for-named-services.

Since scheb/two-factor-bundle requires ^7.1.3 and Symfony 3.4 and Symfony 3.4 requires ^5.5.9|>=7.0.8, requiring >=5.3.0 in this bundle makes no sense.