### PR TITLE
Fixes Symfony 4.2 deprecation messages (backwards compatible)

### DIFF
--- a/Controller/RegisterController.php
+++ b/Controller/RegisterController.php
@@ -2,16 +2,16 @@
 
 namespace R\U2FTwoFactorBundle\Controller;
 
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Symfony\Component\HttpFoundation\Request;
 use R\U2FTwoFactorBundle\Event\RegisterEvent;
 use R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class RegisterController
  * @author Nils Uliczka
  */
-class RegisterController extends Controller
+class RegisterController extends AbstractController
 {
     /**
      * u2fAction

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('r_u2f_two_factor');
+        $treeBuilder = new TreeBuilder('r_u2f_two_factor');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('r_u2f_two_factor');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixes:

* Deprecated constructing a TreeBuilder without passing root node information
* The Controller class has been deprecated, use AbstractController instead.

See https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md