### PR TITLE
scheb/two-factor-bundle v4

### DIFF
--- a/Controller/RegisterController.php
+++ b/Controller/RegisterController.php
@@ -6,16 +6,14 @@ use R\U2FTwoFactorBundle\Event\RegisterEvent;
 use R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Nils Uliczka
  */
 class RegisterController extends AbstractController
 {
-    /**
-     * @param Request $request
-     **/
-    public function u2fAction(Request $request)
+    public function u2fAction(Request $request) : Response
     {
         $u2fAuthenticator = $this->get(U2FAuthenticator::class);
         if ($request->isMethod('POST')) {

--- a/Controller/RegisterController.php
+++ b/Controller/RegisterController.php
@@ -8,15 +8,12 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
- * Class RegisterController
  * @author Nils Uliczka
  */
 class RegisterController extends AbstractController
 {
     /**
-     * u2fAction
      * @param Request $request
-     * @return void
      **/
     public function u2fAction(Request $request)
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -6,7 +6,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
- * This is the class that validates and merges configuration from your app/config files
+ * This is the class that validates and merges configuration from your app/config files.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */

--- a/DependencyInjection/RU2FTwoFactorExtension.php
+++ b/DependencyInjection/RU2FTwoFactorExtension.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
- * This is the class that loads and manages your bundle configuration
+ * This is the class that loads and manages your bundle configuration.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */

--- a/Event/RegisterEvent.php
+++ b/Event/RegisterEvent.php
@@ -3,9 +3,9 @@
 namespace R\U2FTwoFactorBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Class RegisterEvent
  * @author Nils Uliczka
  */
 class RegisterEvent extends Event
@@ -31,11 +31,9 @@ class RegisterEvent extends Event
     protected $response;
 
     /**
-     * __construct
      * @param array  $registration
      * @param User   $user
      * @param string $name
-     * @return void
      **/
     public function __construct($registration, $user, $name)
     {
@@ -45,8 +43,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * getRegistration
-     *
      * @return mixed
      */
     public function getRegistration()
@@ -55,8 +51,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * getUser
-     *
      * @return mixed
      */
     public function getUser()
@@ -65,8 +59,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * setUser
-     *
      * @param mixed $user
      *
      * @return $this
@@ -79,8 +71,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * getResponse
-     *
      * @return mixed
      */
     public function getResponse()
@@ -89,8 +79,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * setResponse
-     *
      * @param mixed $response
      *
      * @return $this
@@ -103,8 +91,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * getKeyName
-     *
      * @return mixed
      */
     public function getKeyName()
@@ -113,8 +99,6 @@ class RegisterEvent extends Event
     }
 
     /**
-     * setKeyName
-     *
      * @param mixed $keyName
      *
      * @return $this

--- a/Model/U2F/TwoFactorInterface.php
+++ b/Model/U2F/TwoFactorInterface.php
@@ -2,25 +2,15 @@
 
 namespace R\U2FTwoFactorBundle\Model\U2F;
 
+use Doctrine\Common\Collections\Collection;
+
 interface TwoFactorInterface
 {
-    /**
-     * @return bool
-     **/
-    public function isU2FAuthEnabled();
+    public function isU2FAuthEnabled(): bool;
 
-    /**
-     * @return array
-     **/
-    public function getU2FKeys();
+    public function getU2FKeys(): Collection;
 
-    /**
-     * @param U2FKey $key
-     **/
-    public function addU2FKey($key);
+    public function addU2FKey(TwoFactorKeyInterface $key);
 
-    /**
-     * @param U2FKey $key
-     **/
-    public function removeU2FKey($key);
+    public function removeU2FKey(TwoFactorKeyInterface $key);
 }

--- a/Model/U2F/TwoFactorInterface.php
+++ b/Model/U2F/TwoFactorInterface.php
@@ -2,9 +2,6 @@
 
 namespace R\U2FTwoFactorBundle\Model\U2F;
 
-/**
- * Interface: TwoFactorInterface.
- */
 interface TwoFactorInterface
 {
     /**

--- a/Model/U2F/TwoFactorInterface.php
+++ b/Model/U2F/TwoFactorInterface.php
@@ -3,35 +3,27 @@
 namespace R\U2FTwoFactorBundle\Model\U2F;
 
 /**
- * Interface: TwoFactorInterface
- *
+ * Interface: TwoFactorInterface.
  */
 interface TwoFactorInterface
 {
-
     /**
-     * isU2FAuthEnabled
-     * @return boolean
+     * @return bool
      **/
     public function isU2FAuthEnabled();
 
     /**
-     * getU2FKeys
      * @return array
      **/
     public function getU2FKeys();
 
     /**
-     * addU2FKey
      * @param U2FKey $key
-     * @return void
      **/
     public function addU2FKey($key);
 
     /**
-     * removeU2FKey
      * @param U2FKey $key
-     * @return void
      **/
     public function removeU2FKey($key);
 }

--- a/Model/U2F/TwoFactorKeyInterface.php
+++ b/Model/U2F/TwoFactorKeyInterface.php
@@ -3,21 +3,18 @@
 namespace R\U2FTwoFactorBundle\Model\U2F;
 
 /**
- * Interface KeyInterface
+ * Interface KeyInterface.
+ *
  * @author Nils Uliczka
  */
 interface TwoFactorKeyInterface
 {
     /**
-     * getKeyHandle
-     *
      * @return mixed
      */
     public function getKeyHandle();
 
     /**
-     * setKeyHandle
-     *
      * @param mixed $keyHandle
      *
      * @return $this
@@ -25,15 +22,11 @@ interface TwoFactorKeyInterface
     public function setKeyHandle($keyHandle);
 
     /**
-     * getpublicKey
-     *
      * @return mixed
      */
     public function getPublicKey();
 
     /**
-     * setPublicKey
-     *
      * @param mixed $publicKey
      *
      * @return $this
@@ -41,15 +34,11 @@ interface TwoFactorKeyInterface
     public function setPublicKey($publicKey);
 
     /**
-     * getCertificate
-     *
      * @return mixed
      */
     public function getCertificate();
 
     /**
-     * setCertificate
-     *
      * @param mixed $certificate
      *
      * @return $this
@@ -57,15 +46,11 @@ interface TwoFactorKeyInterface
     public function setCertificate($certificate);
 
     /**
-     * getCounter
-     *
      * @return mixed
      */
     public function getCounter();
 
     /**
-     * setCounter
-     *
      * @param mixed $counter
      *
      * @return $this
@@ -73,14 +58,13 @@ interface TwoFactorKeyInterface
     public function setCounter($counter);
 
     /**
-     * getName
      * @return string
      **/
     public function getName();
 
     /**
-     * setName
      * @param string $name
+     *
      * @return $this
      **/
     public function setName($name);

--- a/Model/U2F/TwoFactorKeyInterface.php
+++ b/Model/U2F/TwoFactorKeyInterface.php
@@ -3,8 +3,6 @@
 namespace R\U2FTwoFactorBundle\Model\U2F;
 
 /**
- * Interface KeyInterface.
- *
  * @author Nils Uliczka
  */
 interface TwoFactorKeyInterface

--- a/README.md
+++ b/README.md
@@ -49,61 +49,41 @@ For the Authentication to work you User has to implement `R\U2FTwoFactorBundle\M
 <?php
 
 // ...
+use Doctrine\Common\Collections\Collection;
 use R\U2FTwoFactorBundle\Model\U2F\TwoFactorInterface as U2FTwoFactorInterface;
+use R\U2FTwoFactorBundle\Model\U2F\TwoFactorKeyInterface;
 // ...
 class User implements U2FTwoFactorInterface
 {
 // ...
     /**
      * @ORM\OneToMany(targetEntity="Club\BaseBundle\Entity\U2FKey", mappedBy="user")
-     * @var ArrayCollection
+     * @var Collection
      **/
     protected $u2fKeys;
 
-    /**
-     * isU2FAuthEnabled
-     * @return boolean
-     **/
-    public function isU2FAuthEnabled()
+    public function isU2FAuthEnabled(): bool
     {
         // If the User has Keys associated, use U2F
         // You may use a different logic here
         return count($this->u2fKeys) > 0;
     }
 
-    /**
-     * getU2FKeys
-     * @return ArrayCollection
-     **/
-    public function getU2FKeys()
+    public function getU2FKeys(): Collection
     {
         return $this->u2fKeys;
     }
 
-    /**
-     * addU2FKey
-     * @param U2FKey $key
-     * @return void
-     **/
-    public function addU2FKey($key)
+    public function addU2FKey(TwoFactorKeyInterface $key)
     {
         $this->u2fKeys->add($key);
     }
-    
-    /**
-     * removeU2FKey
-     * @param U2FKey $key
-     * @return void
-     **/
-    public function removeU2FKey($key)
+
+    public function removeU2FKey(TwoFactorKeyInterface $key)
     {
         $this->u2fKeys->remove($key);
     }
 
-    /**
-     * __construct
-     * @return void
-     **/
     public function __construct()
     {
         // ...

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Here is an example using doctrine.
 use R\U2FTwoFactorBundle\Model\U2F\TwoFactorKeyInterface;
 
 /**
- * Class U2FKey
  * @ORM\Entity
  * @ORM\Table(name="u2f_keys",
  * uniqueConstraints={@ORM\UniqueConstraint(name="user_unique",columns={"user_id",

--- a/Security/TwoFactor/Provider/U2F/TwoFactorProvider.php
+++ b/Security/TwoFactor/Provider/U2F/TwoFactorProvider.php
@@ -9,7 +9,6 @@ use Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface
 use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
- * Class TwoFactorProvider
  * @author Nils Uliczka
  */
 class TwoFactorProvider implements TwoFactorProviderInterface
@@ -48,7 +47,7 @@ class TwoFactorProvider implements TwoFactorProviderInterface
     {
         $user = $context->getUser();
 
-        return ($user instanceof TwoFactorInterface && $user->isU2FAuthEnabled());
+        return $user instanceof TwoFactorInterface && $user->isU2FAuthEnabled();
     }
 
     /**

--- a/Security/TwoFactor/Provider/U2F/TwoFactorProvider.php
+++ b/Security/TwoFactor/Provider/U2F/TwoFactorProvider.php
@@ -31,13 +31,6 @@ class TwoFactorProvider implements TwoFactorProviderInterface
 
     private $session;
 
-    /**
-     * __construct
-     *
-     * @param U2FAuthenticatorInterface $authenticator
-     * @param \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorFormRendererInterface $formRenderer
-     * @param \Symfony\Component\HttpFoundation\Session\Session $session
-     */
     public function __construct(U2FAuthenticatorInterface $authenticator, TwoFactorFormRendererInterface $formRenderer, Session $session)
     {
         $this->authenticator = $authenticator;
@@ -46,11 +39,11 @@ class TwoFactorProvider implements TwoFactorProviderInterface
         $this->session = $session;
     }
 
-    /**
-     * beginAuthentication
-     * @param AuthenticationContextInterface $context
-     * @return boolean
-     **/
+    public function prepareAuthentication($user): void
+    {
+        return null;
+    }
+
     public function beginAuthentication(AuthenticationContextInterface $context): bool
     {
         $user = $context->getUser();
@@ -60,9 +53,6 @@ class TwoFactorProvider implements TwoFactorProviderInterface
 
     /**
      * @param mixed $user
-     * @param string $authenticationCode
-     *
-     * @return bool
      */
     public function validateAuthenticationCode($user, string $authenticationCode): bool
     {

--- a/Security/TwoFactor/Provider/U2F/TwoFactorProvider.php
+++ b/Security/TwoFactor/Provider/U2F/TwoFactorProvider.php
@@ -19,7 +19,7 @@ class TwoFactorProvider implements TwoFactorProviderInterface
     protected $authenticator;
 
     /**
-     * @var \Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorFormRendererInterface
+     * @var TwoFactorFormRendererInterface
      */
     private $formRenderer;
 

--- a/Security/TwoFactor/Provider/U2F/U2FAuthenticator.php
+++ b/Security/TwoFactor/Provider/U2F/U2FAuthenticator.php
@@ -10,7 +10,6 @@ use u2flib_server\Registration;
 use u2flib_server\U2F;
 
 /**
- * Class U2FAuthenticator
  * @author Nils Uliczka
  */
 class U2FAuthenticator implements U2FAuthenticatorInterface
@@ -26,7 +25,7 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         $host = $requestStack->getCurrentRequest()->getHost();
         $port = $requestStack->getCurrentRequest()->getPort();
         $intPort = (int) $port;
-        $this->u2f = new U2F($scheme.'://'.$host.((80 !== $intPort && 443 !== $intPort)?':'.$port:''));
+        $this->u2f = new U2F($scheme.'://'.$host.((80 !== $intPort && 443 !== $intPort) ? ':'.$port : ''));
     }
 
     /**
@@ -54,7 +53,7 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         return false;
     }
 
-    public function generateRegistrationRequest(UserInterface $user) : array
+    public function generateRegistrationRequest(UserInterface $user): array
     {
         return $this->u2f->getRegisterData($user->getU2FKeys()->toArray());
     }
@@ -63,7 +62,7 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
      * @param string $regRequest
      * @param string $registration
      **/
-    public function doRegistration($regRequest, $registration) : Registration
+    public function doRegistration($regRequest, $registration): Registration
     {
         return $this->u2f->doRegister($regRequest, $registration);
     }

--- a/Security/TwoFactor/Provider/U2F/U2FAuthenticator.php
+++ b/Security/TwoFactor/Provider/U2F/U2FAuthenticator.php
@@ -2,8 +2,11 @@
 
 namespace R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F;
 
+use function json_encode;
+use const JSON_UNESCAPED_SLASHES;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
+use u2flib_server\Registration;
 use u2flib_server\U2F;
 
 /**
@@ -17,11 +20,6 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
      **/
     protected $u2f;
 
-    /**
-     * __construct
-     * @param RequestStack $requestStack
-     * @return void
-     **/
     public function __construct(RequestStack $requestStack)
     {
         $scheme = $requestStack->getCurrentRequest()->getScheme();
@@ -32,19 +30,14 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
     }
 
     /**
-     * generateRequest
-     * @param UserInterface $user
      * @return string
      **/
     public function generateRequest(UserInterface $user)
     {
-        return $this->u2f->getAuthenticateData($user->getU2FKeys()->toArray());
+        return json_encode($this->u2f->getAuthenticateData($user->getU2FKeys()->toArray()), JSON_UNESCAPED_SLASHES);
     }
 
     /**
-     * checkRequest
-     *
-     * @param UserInterface $user
      * @param array $requests
      * @param mixed $authData
      *
@@ -61,23 +54,16 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         return false;
     }
 
-    /**
-     * generateRegistrationRequest
-     * @param UserInterface $user
-     * @return string
-     **/
-    public function generateRegistrationRequest(UserInterface $user)
+    public function generateRegistrationRequest(UserInterface $user) : array
     {
         return $this->u2f->getRegisterData($user->getU2FKeys()->toArray());
     }
 
     /**
-     * doRegistration
      * @param string $regRequest
      * @param string $registration
-     * @return void
      **/
-    public function doRegistration($regRequest, $registration)
+    public function doRegistration($regRequest, $registration) : Registration
     {
         return $this->u2f->doRegister($regRequest, $registration);
     }

--- a/Security/TwoFactor/Provider/U2F/U2FAuthenticator.php
+++ b/Security/TwoFactor/Provider/U2F/U2FAuthenticator.php
@@ -4,7 +4,7 @@ namespace R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F;
 
 use function json_encode;
 use const JSON_UNESCAPED_SLASHES;
-use Symfony\Component\Security\Core\User\UserInterface;
+use R\U2FTwoFactorBundle\Model\U2F\TwoFactorInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use u2flib_server\Registration;
 use u2flib_server\U2F;
@@ -28,10 +28,7 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         $this->u2f = new U2F($scheme.'://'.$host.((80 !== $intPort && 443 !== $intPort) ? ':'.$port : ''));
     }
 
-    /**
-     * @return string
-     **/
-    public function generateRequest(UserInterface $user)
+    public function generateRequest(TwoFactorInterface $user): string
     {
         return json_encode($this->u2f->getAuthenticateData($user->getU2FKeys()->toArray()), JSON_UNESCAPED_SLASHES);
     }
@@ -39,10 +36,8 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
     /**
      * @param array $requests
      * @param mixed $authData
-     *
-     * @return bool
      */
-    public function checkRequest(UserInterface $user, array $requests, $authData)
+    public function checkRequest(TwoFactorInterface $user, array $requests, $authData): bool
     {
         $reg = $this->u2f->doAuthenticate($requests, $user->getU2FKeys()->toArray(), json_decode($authData));
 
@@ -53,7 +48,7 @@ class U2FAuthenticator implements U2FAuthenticatorInterface
         return false;
     }
 
-    public function generateRegistrationRequest(UserInterface $user): array
+    public function generateRegistrationRequest(TwoFactorInterface $user): array
     {
         return $this->u2f->getRegisterData($user->getU2FKeys()->toArray());
     }

--- a/Security/TwoFactor/Provider/U2F/U2FAuthenticatorInterface.php
+++ b/Security/TwoFactor/Provider/U2F/U2FAuthenticatorInterface.php
@@ -2,26 +2,18 @@
 
 namespace R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F;
 
-use Symfony\Component\Security\Core\User\UserInterface;
+use R\U2FTwoFactorBundle\Model\U2F\TwoFactorInterface;
 
 /**
  * @author Nils Uliczka
  */
 interface U2FAuthenticatorInterface
 {
-    /**
-     * @param UserInterface $user
-     *
-     * @return string
-     **/
-    public function generateRequest(UserInterface $user);
+    public function generateRequest(TwoFactorInterface $user): string;
 
     /**
-     * @param UserInterface $user
      * @param array         $requests
      * @param mixed         $authData
-     *
-     * @return bool
      **/
-    public function checkRequest(UserInterface $user, array $requests, $authData);
+    public function checkRequest(TwoFactorInterface $user, array $requests, $authData): bool;
 }

--- a/Security/TwoFactor/Provider/U2F/U2FAuthenticatorInterface.php
+++ b/Security/TwoFactor/Provider/U2F/U2FAuthenticatorInterface.php
@@ -5,24 +5,23 @@ namespace R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 /**
- * Class U2FAuthenticatorInterface
  * @author Nils Uliczka
  */
 interface U2FAuthenticatorInterface
 {
     /**
-     * generateRequest
      * @param UserInterface $user
+     *
      * @return string
      **/
     public function generateRequest(UserInterface $user);
 
     /**
-     * checkRequest
      * @param UserInterface $user
-     * @param array                 $requests
-     * @param mixed                 $authData
-     * @return boolean
+     * @param array         $requests
+     * @param mixed         $authData
+     *
+     * @return bool
      **/
     public function checkRequest(UserInterface $user, array $requests, $authData);
 }

--- a/Security/TwoFactor/Provider/U2F/U2FFormRenderer.php
+++ b/Security/TwoFactor/Provider/U2F/U2FFormRenderer.php
@@ -36,7 +36,7 @@ class U2FFormRenderer implements TwoFactorFormRendererInterface
     {
         $user = $this->token->getUser();
 
-        $authenticationData = json_encode($this->authenticator->generateRequest($user), JSON_UNESCAPED_SLASHES);
+        $authenticationData = $this->authenticator->generateRequest($user);
 
         $templateVars['authenticationData'] = $authenticationData;
 

--- a/Security/TwoFactor/Provider/U2F/U2FFormRenderer.php
+++ b/Security/TwoFactor/Provider/U2F/U2FFormRenderer.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Twig\Environment;
 
 class U2FFormRenderer implements TwoFactorFormRendererInterface
@@ -21,7 +22,14 @@ class U2FFormRenderer implements TwoFactorFormRendererInterface
     private $template;
 
     private $authenticator;
+    /**
+     * @var TokenInterface|null
+     */
     private $token;
+    /**
+     * @var Session
+     */
+    private $session;
 
     public function __construct(Environment $twigRenderer, string $template, U2FAuthenticator $authenticator, TokenStorageInterface $tokenStorage, Session $session)
     {

--- a/Security/TwoFactor/Provider/U2F/U2FFormRenderer.php
+++ b/Security/TwoFactor/Provider/U2F/U2FFormRenderer.php
@@ -45,6 +45,7 @@ class U2FFormRenderer implements TwoFactorFormRendererInterface
         $content = $this->twigEnvironment->render($this->template, $templateVars);
         $response = new Response();
         $response->setContent($content);
+
         return $response;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.1.3",
         "ext-json": "*",
+        "doctrine/common": "*",
         "scheb/two-factor-bundle": "^3.2.0|^4.0.0",
         "yubico/u2flib-server": "^1.0.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         }
     ],
     "require": {
-        "scheb/two-factor-bundle": "^3.2.0",
+        "php": "^7.1.3",
+        "ext-json": "*",
+        "scheb/two-factor-bundle": "^3.2.0|^4.0.0",
         "yubico/u2flib-server": "^1.0.0"
     },
     "conflict": {


### PR DESCRIPTION
- Added prepareAuthentication() to comply with the changed `\Scheb\TwoFactorBundle\Security\TwoFactor\Provider\TwoFactorProviderInterface`
- Added return type and parameter type hint for TwoFactorInterface. BC break, but we're still on 0.x version.
- Removed some useless docblock lines, because PHP7-style parameter or return types where in place already. 
- Fixed `\R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator::generateRequest`, which didn't return a string, while this is required by `\R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticatorInterface`
- Used php-cs-fixer (with Symfony Code Standard) for some small changes

Feedback requested:
- [x] Since Scheb 4 has some breaking changes, maybe this is the time for us to have breaking changes as well? For instance, `U2FAuthenticatorInterface` doesn't use return types.