### PR TITLE
Add Symfony5 support

### DIFF
--- a/Controller/RegisterController.php
+++ b/Controller/RegisterController.php
@@ -4,6 +4,7 @@ namespace R\U2FTwoFactorBundle\Controller;
 
 use R\U2FTwoFactorBundle\Event\RegisterEvent;
 use R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -30,12 +31,14 @@ class RegisterController extends AbstractController
         U2FAuthenticator $u2fAuthenticator,
         SessionInterface $session,
         EventDispatcherInterface $eventDispatcher,
+        ContainerInterface $container,
         string $registerTemplate
     ) {
         $this->u2fAuthenticator = $u2fAuthenticator;
         $this->session = $session;
         $this->eventDispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
         $this->registerTemplate = $registerTemplate;
+        $this->container = $container;
     }
 
     public function u2fAction(Request $request): Response

--- a/Event/RegisterEvent.php
+++ b/Event/RegisterEvent.php
@@ -2,7 +2,7 @@
 
 namespace R\U2FTwoFactorBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Symfony\Component\HttpFoundation\Response;
 use R\U2FTwoFactorBundle\Model\U2F\TwoFactorInterface;
 use u2flib_server\Registration;

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,3 +1,3 @@
 club_base_register_u2f:
     path:   /u2f_register
-    defaults: { _controller: RU2FTwoFactorBundle:Register:u2f }
+    defaults: { _controller: R\U2FTwoFactorBundle\Controller\RegisterController::u2fAction }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -22,5 +22,6 @@ services:
         arguments:
             $u2fAuthenticator: '@R\U2FTwoFactorBundle\Security\TwoFactor\Provider\U2F\U2FAuthenticator'
             $session: '@session'
+            $container: '@service_container'
             $eventDispatcher: '@event_dispatcher'
             $registerTemplate: '%r_u2f_two_factor.registerTemplate%'

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,10 @@
         "doctrine/common": "*",
         "scheb/two-factor-bundle": "^3.2.0|^4.0.0",
         "yubico/u2flib-server": "^1.0.0",
-        "symfony/framework-bundle": "^3.4|^4.0",
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0",
         "symfony/templating": "^3.4|^4.0",
-        "doctrine/collections": "^1.6"
+        "doctrine/collections": "^1.6",
+        "symfony/event-dispatcher-contracts": "^2.0"
     },
     "conflict": {
         "tubssz/u2f-two-factor-bundle": "*",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "scheb/two-factor-bundle": "^3.2.0|^4.0.0",
         "yubico/u2flib-server": "^1.0.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0",
-        "symfony/templating": "^3.4|^4.0",
+        "symfony/templating": "^3.4|^4.0|^5.0",
         "doctrine/collections": "^1.6",
         "symfony/event-dispatcher-contracts": "^2.0"
     },


### PR DESCRIPTION
Pull request https://github.com/darookee/u2f-two-factor-bundle/pull/50 gives me some exceptions, when using the built in RegistrationController.
I have updated the routes.yaml definition, to use the new controller syntax. (the old one was removed in Symfony 5).

I also encountered a "R\U2FTwoFactorBundle\Controller\RegisterController" has no container set, did you forget to define it as a service subscriber?".
I am not quite sure why this happening, I found a workaround by injecting the container via constructor. Maybe someone finds a better solution for this...
